### PR TITLE
Center sound buttons within their containers

### DIFF
--- a/style.css
+++ b/style.css
@@ -93,6 +93,8 @@ nav a:hover::after {
   height: 100px;
   border: none;
   background-color: transparent;
+  margin-left: 50%;
+  transform: translateX(-50%);
 }
 
 .soundboard img {


### PR DESCRIPTION
This pull request centers the sound buttons within their containers using `margin-left` and `transform` CSS properties.

### Before
![image](https://github.com/DaSmelterSaif/Soundboard_Challenge/assets/49250671/5cb14c91-5178-486b-bf64-8cc98497d35c)
### After
![image](https://github.com/DaSmelterSaif/Soundboard_Challenge/assets/49250671/af0febbd-0e03-4d07-8807-abcfc997229e)
